### PR TITLE
Replace URL etalab-tiles.fr by openmaptiles.data.gouv.fr

### DIFF
--- a/client/components/carte/Map.vue
+++ b/client/components/carte/Map.vue
@@ -66,7 +66,7 @@ onMounted(() => {
 
   map.value = new maplibregl.Map({
     container: mapContainer.value,
-    style: `https://etalab-tiles.fr/styles/osm-bright/style.json`,
+    style: `https://openmaptiles.data.gouv.fr/styles/osm-bright/style.json`,
     bounds: initialState,
   });
 
@@ -98,7 +98,7 @@ onMounted(() => {
     map.value?.addSource('cadastre', {
       type: 'vector',
       url:
-        `https://etalab-tiles.fr/data/decoupage-administratif.json`,
+        `https://openmaptiles.data.gouv.fr/data/decoupage-administratif.json`,
     });
     addSourceAndLayerZones(PMTILES_URL);
   });

--- a/client/components/stats/DepartementMap.vue
+++ b/client/components/stats/DepartementMap.vue
@@ -26,7 +26,7 @@ onMounted(() => {
 
   map.value = new maplibregl.Map({
     container: mapContainer.value,
-    style: `https://etalab-tiles.fr/styles/osm-bright/style.json`,
+    style: `https://openmaptiles.data.gouv.fr/styles/osm-bright/style.json`,
     bounds: initialState
   });
 
@@ -76,7 +76,7 @@ onMounted(() => {
     map.value?.addSource('cadastre', {
       type: 'vector',
       url:
-          `https://etalab-tiles.fr/data/decoupage-administratif.json`
+          `https://openmaptiles.data.gouv.fr/data/decoupage-administratif.json`
     });
     map.value?.addLayer({
       id: 'departements-data',


### PR DESCRIPTION
We want to deprecate the domain and this is one of the only website consuming nowadays the URL
PS: URL was intended only for Covid Dashboard and has been use elsewhere whereas it should have not